### PR TITLE
Fixed README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Three.js renderer for large data set of points
 With [npm](https://npmjs.org) do:
 
 ```
-npm install unrender
+npm install https://github.com/anvaka/unrender.git
 ```
 
 # license


### PR DESCRIPTION
`npm install unrender` installs a [package](https://www.npmjs.com/package/unrender) that is not related with this repository